### PR TITLE
revert: 'fix crashing when launching apps with gtk 3.24.37'

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -340,10 +340,7 @@ void wf::compositor_core_impl_t::init()
     wlr_fractional_scale_manager_v1_create(display, 1);
 
     wf_shell  = wayfire_shell_create(display);
-    // disable gtk-shell because gtk 3.24.37 tries xdg-activation and fallbacks
-    // to gtk-shell, but the activation code (requesting focus) doesn't check
-    // if xdg-activation is supported.
-    // gtk_shell = wf_gtk_shell_create(display);
+    gtk_shell = wf_gtk_shell_create(display);
 
     image_io::init();
     OpenGL::init();

--- a/src/output/gtk-shell.cpp
+++ b/src/output/gtk-shell.cpp
@@ -367,7 +367,6 @@ wf_gtk_shell *wf_gtk_shell_create(wl_display *display)
  */
 std::string wf_gtk_shell_get_custom_app_id(wf_gtk_shell *shell, wl_resource *surface)
 {
-    if (!shell) return "";
     return shell->surface_app_id[surface];
 }
 


### PR DESCRIPTION
After upgrading GTK from version 4.10.5 to 4.12.0, it has been observed that the commit 19acd7f2945f4ccbf77a2ba91006cf99b60649de leads to a crash in Nautilus when attempting to open files with GTK applications. Furthermore, without this commit, the issue of application launching crashing would not occur with gtk 3.24.38.
