### PR TITLE
跟踪最新的wlroots以及wayfire改动

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     container: alpine:edge
     steps:
-    - run: apk --no-cache add git gcc g++ binutils pkgconf meson ninja musl-dev wayland-dev wayland-protocols libinput-dev libevdev-dev libxkbcommon-dev pixman-dev glm-dev libdrm-dev mesa-dev cairo-dev pango-dev eudev-dev libxml2-dev libseat-dev libxcb-dev xcb-util-wm-dev xwayland doctest doctest-dev cmake hwdata
+    - run: apk --no-cache add git gcc g++ binutils pkgconf meson ninja musl-dev wayland-dev wayland-protocols libinput-dev libevdev-dev libxkbcommon-dev pixman-dev glm-dev libdrm-dev mesa-dev cairo-dev pango-dev eudev-dev libxml2-dev libseat-dev libxcb-dev xcb-util-wm-dev xwayland doctest doctest-dev cmake libdisplay-info-dev hwdata-dev
     - uses: actions/checkout@v1
     - run: git config --global --add safe.directory /__w/wayfire/wayfire
     - run: git submodule sync --recursive && git submodule update --init --force --recursive
@@ -23,7 +23,7 @@ jobs:
     steps:
     - run: sed -i 's/SigLevel    = Required DatabaseOptional/SigLevel    = Optional TrustAll/' /etc/pacman.conf
     - run: pacman --noconfirm --noprogressbar -Syyu
-    - run: pacman --noconfirm --noprogressbar -Sy git clang lld libc++ pkgconf meson ninja wayland wayland-protocols libinput libxkbcommon pixman glm libdrm libglvnd cairo pango systemd scdoc base-devel seatd
+    - run: pacman --noconfirm --noprogressbar -Sy git clang lld libc++ pkgconf meson ninja wayland wayland-protocols libinput libxkbcommon pixman glm libdrm libglvnd cairo pango systemd scdoc base-devel seatd hwdata libdisplay-info
 
       # Build Wayfire
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ These are the dependencies needed for building Wayfire.
 These are the dependencies needed for building wlroots, and should be installed before building it.
 They are relevant for cases when the system doesn't have a version of wlroots installed.
 
+#### DRM Backend (optional, but you most likely want this)
+
+- [libdisplay-info-dev](https://gitlab.freedesktop.org/emersion/libdisplay-info)
+- [hwdata-dev](https://github.com/vcrhonek/hwdata)
+
 #### Session Provider (optional, recommended)
 
 - [systemd](https://systemd.io/) **or**

--- a/ipc-scripts/move-to-workspace.py
+++ b/ipc-scripts/move-to-workspace.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python3
+
+"""Example script that moves all the windows for a given app ID to the specified workspace.
+
+    Usage: move-to-workspace <app-id> <workspace_x> <workspace_y>"
+"""
+
+import os
+import sys
+
+from wayfire_socket import *
+
+
+def move_to_workspace(s: WayfireSocket, view, ws_x: int, ws_y: int):
+    output = s.query_output(view["output"])
+    xsize = output["workarea"]["width"]
+    ysize = output["workarea"]["height"]
+    cur_ws_x = output["workspace"]["x"]
+    cur_ws_y = output["workspace"]["y"]
+
+    geometry = view["geometry"]
+    x = (geometry["x"] % xsize) + xsize * (ws_x - cur_ws_x)
+    y = (geometry["y"] % ysize) + ysize * (ws_y - cur_ws_y)
+    w = geometry["width"]
+    h = geometry["height"]
+
+    s.configure_view(view["id"], x, y, w, h)
+
+
+def move_all_to_workspace(app_id, x, y):
+    s = WayfireSocket(os.getenv("WAYFIRE_SOCKET"))
+    for view in s.list_views():
+        if view["app-id"] != app_id:
+            continue
+        print("Moving %s(%d) to workspace (%d, %d)" %
+              (app_id, view["id"], x, y))
+        move_to_workspace(s, view, x, y)
+    s.close()
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 4:
+        sys.exit(sys.modules[__name__].__doc__)
+    move_all_to_workspace(sys.argv[1], int(sys.argv[2]), int(sys.argv[3]))

--- a/ipc-scripts/wayfire_socket.py
+++ b/ipc-scripts/wayfire_socket.py
@@ -59,6 +59,9 @@ class WayfireSocket:
         message["data"]["id"] = output_id
         return self.send_json(message)
 
+    def list_views(self):
+        return self.send_json(get_msg_template("window-rules/list_views"))
+
     def configure_view(self, view_id: int, x: int, y: int, w: int, h: int):
         message = get_msg_template("window-rules/configure-view")
         message["data"]["id"] = view_id

--- a/ipc-scripts/wayfire_socket.py
+++ b/ipc-scripts/wayfire_socket.py
@@ -35,7 +35,10 @@ class WayfireSocket:
     def read_message(self):
         rlen = int.from_bytes(self.read_exact(4), byteorder="little")
         response_message = self.read_exact(rlen)
-        return js.loads(response_message)
+        response = js.loads(response_message)
+        if "error" in response:
+            raise Exception(response["error"])
+        return response
 
     def send_json(self, msg):
         data = js.dumps(msg).encode('utf8')
@@ -43,6 +46,9 @@ class WayfireSocket:
         self.client.send(header)
         self.client.send(data)
         return self.read_message()
+
+    def close(self):
+      self.client.close()
 
     def watch(self):
         message = get_msg_template("window-rules/events/watch")
@@ -57,7 +63,6 @@ class WayfireSocket:
         message = get_msg_template("window-rules/configure-view")
         message["data"]["id"] = view_id
         message["data"]["geometry"] = geometry_to_json(x, y, w, h)
-        print(message)
         return self.send_json(message)
 
     def assign_slot(self, view_id: int, slot: str):

--- a/meson.build
+++ b/meson.build
@@ -39,11 +39,11 @@ if get_option('use_system_wlroots').disabled()
 
 elif get_option('use_system_wlroots').enabled()
 	use_system_wlroots = true
-	wlroots = dependency('wlroots', version: ['>=0.16.0', '<0.17.0'], required: true)
+	wlroots = dependency('wlroots', version: ['>=0.17.0', '<0.18.0'], required: true)
 
 elif get_option('use_system_wlroots').auto()
 	message( 'SEARCHING FOR WLROOTS' )
-	wlroots = dependency('wlroots', version: ['>=0.16.0', '<0.17.0'], required: false)
+	wlroots = dependency('wlroots', version: ['>=0.17.0', '<0.18.0'], required: false)
 	use_system_wlroots = true
 	if not wlroots.found()
 		use_system_wlroots = false

--- a/plugins/cube/cube.cpp
+++ b/plugins/cube/cube.cpp
@@ -124,7 +124,6 @@ class wayfire_cube : public wf::per_output_plugin_instance_t, public wf::pointer
                 }
 
                 self->cube->render(target.translated(-wf::origin(self->get_bounding_box())), framebuffers);
-                wf::scene::damage_node(self, self->get_bounding_box());
             }
 
             void compute_visibility(wf::output_t *output, wf::region_t& visible) override
@@ -664,6 +663,7 @@ class wayfire_cube : public wf::per_output_plugin_instance_t, public wf::pointer
     wf::effect_hook_t pre_hook = [=] ()
     {
         update_view_matrix();
+        wf::scene::damage_node(render_node, render_node->get_bounding_box());
         if (animation.cube_animation.running())
         {
             output->render->schedule_redraw();

--- a/plugins/decor/deco-layout.cpp
+++ b/plugins/decor/deco-layout.cpp
@@ -186,7 +186,11 @@ wf::region_t decoration_layout_t::calculate_region() const
     wf::region_t r{};
     for (auto& area : layout_areas)
     {
-        r |= area->get_geometry();
+        auto g = area->get_geometry();
+        if ((g.width > 0) && (g.height > 0))
+        {
+            r |= g;
+        }
     }
 
     return r;

--- a/plugins/protocols/foreign-toplevel.cpp
+++ b/plugins/protocols/foreign-toplevel.cpp
@@ -85,9 +85,9 @@ class wayfire_foreign_toplevel
         } else if (app_id_mode == "full")
         {
 #if WF_HAS_XWAYLAND
-            if (view->get_wlr_surface() && wlr_surface_is_xwayland_surface(view->get_wlr_surface()))
+            if (wlr_xwayland_surface *xw_surface =
+                    wlr_xwayland_surface_try_from_wlr_surface(view->get_wlr_surface()))
             {
-                auto xw_surface = wlr_xwayland_surface_from_wlr_surface(view->get_wlr_surface());
                 ev.app_id = nonull(xw_surface->instance);
             }
 

--- a/plugins/protocols/gtk-shell.cpp
+++ b/plugins/protocols/gtk-shell.cpp
@@ -253,9 +253,8 @@ static void handle_gtk_shell_get_gtk_surface(wl_client *client, wl_resource *res
         gtk_surface, handle_gtk_surface_destroy);
 
     wlr_surface *wlr_surface = wlr_surface_from_resource(surface);
-    if (wlr_surface_is_xdg_surface(wlr_surface))
+    if (wlr_xdg_surface *xdg_surface = wlr_xdg_surface_try_from_wlr_surface(wlr_surface))
     {
-        wlr_xdg_surface *xdg_surface = wlr_xdg_surface_from_wlr_surface(wlr_surface);
         gtk_surface->on_configure.set_callback([=] (void*)
         {
             handle_xdg_surface_on_configure(gtk_surface);

--- a/plugins/single_plugins/ipc-rules.cpp
+++ b/plugins/single_plugins/ipc-rules.cpp
@@ -12,6 +12,7 @@
 #include "plugins/ipc/ipc-method-repository.hpp"
 #include "wayfire/core.hpp"
 #include "wayfire/object.hpp"
+#include "wayfire/plugins/common/util.hpp"
 #include "wayfire/unstable/wlr-surface-node.hpp"
 #include "wayfire/plugins/common/shared-core-data.hpp"
 #include "wayfire/signal-definitions.hpp"
@@ -166,6 +167,7 @@ class ipc_rules_t : public wf::plugin_interface_t, public wf::per_output_tracker
             v["base-geometry"] = wf::ipc::geometry_to_json(get_view_base_geometry(view));
             v["bbox"]   = wf::ipc::geometry_to_json(view->get_bounding_box());
             v["output"] = view->get_output() ? view->get_output()->to_string() : "null";
+            v["last-focus-timestamp"] = wf::get_focus_timestamp(view);
 
             v["state"] = {};
             v["state"]["mapped"]    = view->is_mapped();

--- a/plugins/single_plugins/ipc-rules.cpp
+++ b/plugins/single_plugins/ipc-rules.cpp
@@ -25,6 +25,24 @@
 #include <wayfire/nonstd/wlroots-full.hpp>
 
 
+static std::string role_to_string(enum wf::view_role_t role)
+{
+    switch (role)
+    {
+      case wf::VIEW_ROLE_TOPLEVEL:
+        return "toplevel";
+
+      case wf::VIEW_ROLE_UNMANAGED:
+        return "unmanaged";
+
+      case wf::VIEW_ROLE_DESKTOP_ENVIRONMENT:
+        return "desktop-environment";
+
+      default:
+        return "unknown";
+    }
+}
+
 static std::string layer_to_string(std::optional<wf::scene::layer> layer)
 {
     if (!layer.has_value())
@@ -168,6 +186,7 @@ class ipc_rules_t : public wf::plugin_interface_t, public wf::per_output_tracker
             v["bbox"]   = wf::ipc::geometry_to_json(view->get_bounding_box());
             v["output"] = view->get_output() ? view->get_output()->to_string() : "null";
             v["last-focus-timestamp"] = wf::get_focus_timestamp(view);
+            v["role"] = role_to_string(view->role);
 
             v["state"] = {};
             v["state"]["mapped"]    = view->is_mapped();

--- a/plugins/single_plugins/ipc-rules.cpp
+++ b/plugins/single_plugins/ipc-rules.cpp
@@ -179,12 +179,14 @@ class ipc_rules_t : public wf::plugin_interface_t, public wf::per_output_tracker
         for (auto& view : wf::get_core().get_all_views())
         {
             nlohmann::json v;
+            auto output = view->get_output();
             v["id"]     = view->get_id();
             v["title"]  = view->get_title();
             v["app-id"] = view->get_app_id();
             v["base-geometry"] = wf::ipc::geometry_to_json(get_view_base_geometry(view));
             v["bbox"]   = wf::ipc::geometry_to_json(view->get_bounding_box());
-            v["output"] = view->get_output() ? view->get_output()->to_string() : "null";
+            v["output"] = output ? output->to_string() : "null";
+            v["output-id"] = output ? output->get_id() : -1;
             v["last-focus-timestamp"] = wf::get_focus_timestamp(view);
             v["role"] = role_to_string(view->role);
 

--- a/plugins/single_plugins/ipc-rules.cpp
+++ b/plugins/single_plugins/ipc-rules.cpp
@@ -374,7 +374,7 @@ class ipc_rules_t : public wf::plugin_interface_t, public wf::per_output_tracker
         {
 #if WF_HAS_XWAYLAND
             auto surf = view->get_wlr_surface();
-            if (surf && wlr_surface_is_xwayland_surface(surf))
+            if (surf && wlr_xwayland_surface_try_from_wlr_surface(surf))
             {
                 return "x-or";
             }

--- a/plugins/single_plugins/oswitch.cpp
+++ b/plugins/single_plugins/oswitch.cpp
@@ -21,6 +21,7 @@ class wayfire_oswitch : public wf::plugin_interface_t
         idle_next_output.run_once([=] ()
         {
             wf::get_core().seat->focus_output(next);
+            next->ensure_pointer(true);
         });
 
         return true;
@@ -43,6 +44,7 @@ class wayfire_oswitch : public wf::plugin_interface_t
         idle_next_output.run_once([=] ()
         {
             wf::get_core().seat->focus_output(next);
+            next->ensure_pointer(true);
         });
 
         return true;

--- a/plugins/window-rules/view-action-interface.hpp
+++ b/plugins/window-rules/view-action-interface.hpp
@@ -17,7 +17,7 @@ class view_action_interface_t : public action_interface_t
     virtual bool execute(const std::string & name,
         const std::vector<variant_t> & args) override;
 
-    void set_view(wayfire_toplevel_view view);
+    void set_view(wayfire_view view);
 
   private:
     void _maximize();
@@ -55,6 +55,7 @@ class view_action_interface_t : public action_interface_t
     wf::geometry_t _get_workspace_grid_geometry(wf::output_t *output) const;
 
     wayfire_toplevel_view _view;
+    wayfire_view _nontoplevel;
 };
 } // End namespace wf.
 

--- a/plugins/window-rules/window-rules.cpp
+++ b/plugins/window-rules/window-rules.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-#include <cfloat>
 #include <memory>
 #include <vector>
 
@@ -26,7 +24,7 @@ class wayfire_window_rules_t : public wf::per_output_plugin_instance_t
   public:
     void init() override;
     void fini() override;
-    void apply(const std::string & signal, wayfire_toplevel_view view);
+    void apply(const std::string & signal, wayfire_view view);
 
   private:
     void setup_rules_from_config();
@@ -35,7 +33,7 @@ class wayfire_window_rules_t : public wf::per_output_plugin_instance_t
     // Created rule handler.
     wf::signal::connection_t<wf::view_mapped_signal> on_view_mapped = [=] (wf::view_mapped_signal *ev)
     {
-        apply("created", toplevel_cast(ev->view));
+        apply("created", ev->view);
     };
 
     // Maximized rule handler.
@@ -95,19 +93,20 @@ void wayfire_window_rules_t::fini()
     }
 }
 
-void wayfire_window_rules_t::apply(const std::string & signal, wayfire_toplevel_view view)
+void wayfire_window_rules_t::apply(const std::string & signal, wayfire_view view)
 {
     if (view == nullptr)
     {
         return;
     }
 
-    if ((signal == "maximized") && (view->pending_tiled_edges() != wf::TILED_EDGES_ALL))
+    auto toplevel = toplevel_cast(view);
+    if ((signal == "maximized") && (!toplevel || (toplevel->pending_tiled_edges() != wf::TILED_EDGES_ALL)))
     {
         return;
     }
 
-    if ((signal == "unmaximized") && (view->pending_tiled_edges() == wf::TILED_EDGES_ALL))
+    if ((signal == "unmaximized") && (!toplevel || (toplevel->pending_tiled_edges() == wf::TILED_EDGES_ALL)))
     {
         return;
     }

--- a/proto/meson.build
+++ b/proto/meson.build
@@ -22,7 +22,6 @@ wayland_scanner_client = generator(
 
 server_protocols = [
 	[wl_protocol_dir, 'stable/xdg-shell/xdg-shell.xml'],
-	[wl_protocol_dir, 'unstable/idle-inhibit/idle-inhibit-unstable-v1.xml'],
 	[wl_protocol_dir, 'unstable/linux-dmabuf/linux-dmabuf-unstable-v1.xml'],
 	[wl_protocol_dir, 'unstable/xdg-shell/xdg-shell-unstable-v6.xml'],
     [wl_protocol_dir, 'unstable/xdg-output/xdg-output-unstable-v1.xml'],

--- a/src/api/wayfire/core.hpp
+++ b/src/api/wayfire/core.hpp
@@ -101,6 +101,7 @@ class compositor_core_t : public wf::object_base_t, public signal::provider_t
      * used instead of this one
      */
     wlr_backend *backend;
+    wlr_session *session;
     wlr_renderer *renderer;
     wlr_allocator *allocator;
 
@@ -127,7 +128,7 @@ class compositor_core_t : public wf::object_base_t, public signal::provider_t
         wlr_virtual_keyboard_manager_v1 *vkbd_manager;
         wlr_virtual_pointer_manager_v1 *vptr_manager;
         wlr_input_inhibit_manager *input_inhibit;
-        wlr_idle *idle;
+        wlr_idle_notifier_v1 *idle_notifier;
         wlr_idle_inhibit_manager_v1 *idle_inhibit;
         wlr_pointer_gestures_v1 *pointer_gestures;
         wlr_relative_pointer_manager_v1 *relative_pointer;

--- a/src/api/wayfire/idle.hpp
+++ b/src/api/wayfire/idle.hpp
@@ -19,6 +19,6 @@ class idle_inhibitor_t
 
   private:
     static unsigned int inhibitors;
-    void notify_wlroots();
+    void notify_update();
 };
 }

--- a/src/api/wayfire/nonstd/wlroots-full.hpp
+++ b/src/api/wayfire/nonstd/wlroots-full.hpp
@@ -24,6 +24,7 @@ extern "C"
 #define static
 #include <wlr/types/wlr_compositor.h>
 #include <wlr/render/wlr_renderer.h>
+#include <wlr/render/swapchain.h>
 #include <wlr/render/allocator.h>
 #include <wlr/render/gles2.h>
 #include <wlr/render/egl.h>
@@ -32,7 +33,7 @@ extern "C"
 #include <wlr/types/wlr_buffer.h>
 #include <wlr/types/wlr_viewporter.h>
 
-#include <wlr/types/wlr_output_damage.h>
+#include <wlr/types/wlr_damage_ring.h>
 #include <wlr/types/wlr_presentation_time.h>
 #include <wlr/util/region.h>
 #include <wlr/types/wlr_screencopy_v1.h>
@@ -117,7 +118,6 @@ extern "C"
 #include <wlr/types/wlr_switch.h>
 #include <wlr/types/wlr_xcursor_manager.h>
 #include <wlr/types/wlr_pointer_gestures_v1.h>
-#include <wlr/types/wlr_idle.h>
 #include <wlr/interfaces/wlr_keyboard.h>
 #include <wlr/types/wlr_touch.h>
 #include <wlr/types/wlr_pointer_gestures_v1.h>
@@ -125,6 +125,7 @@ extern "C"
 #include <wlr/types/wlr_data_control_v1.h>
 #include <wlr/types/wlr_virtual_keyboard_v1.h>
 #include <wlr/types/wlr_virtual_pointer_v1.h>
+#include <wlr/types/wlr_idle_notify_v1.h>
 #include <wlr/types/wlr_idle_inhibit_v1.h>
 #include <wlr/types/wlr_input_inhibitor.h>
 #define delete delete_

--- a/src/api/wayfire/nonstd/wlroots.hpp
+++ b/src/api/wayfire/nonstd/wlroots.hpp
@@ -21,12 +21,12 @@ extern "C"
     struct wlr_xdg_output_manager_v1;
     struct wlr_export_dmabuf_manager_v1;
     struct wlr_server_decoration_manager;
-    struct wlr_xdg_decoration_manager_v1;
     struct wlr_input_inhibit_manager;
+    struct wlr_idle_inhibit_manager_v1;
+    struct wlr_xdg_decoration_manager_v1;
     struct wlr_virtual_keyboard_manager_v1;
     struct wlr_virtual_pointer_manager_v1;
-    struct wlr_idle;
-    struct wlr_idle_inhibit_manager_v1;
+    struct wlr_idle_notifier_v1;
     struct wlr_screencopy_manager_v1;
     struct wlr_foreign_toplevel_manager_v1;
     struct wlr_pointer_gestures_v1;
@@ -53,7 +53,10 @@ extern "C"
 #include <wlr/types/wlr_pointer.h>
 #include <wlr/types/wlr_keyboard.h>
 #include <wlr/types/wlr_touch.h>
+#define static
 #include <wlr/types/wlr_output.h>
+#undef static
+#include <wlr/backend/session.h>
 #include <wlr/util/box.h>
 #include <wlr/util/edges.h>
 #include <wayland-server.h>

--- a/src/api/wayfire/plugin.hpp
+++ b/src/api/wayfire/plugin.hpp
@@ -108,7 +108,7 @@ class plugin_interface_t
 using wayfire_plugin_load_func = wf::plugin_interface_t * (*)();
 
 /** The version of Wayfire's API/ABI */
-constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2023'10'25;
+constexpr uint32_t WAYFIRE_API_ABI_VERSION = 2023'11'23;
 
 /**
  * Each plugin must also provide a function which returns the Wayfire API/ABI

--- a/src/api/wayfire/render-manager.hpp
+++ b/src/api/wayfire/render-manager.hpp
@@ -148,16 +148,17 @@ class render_manager
      * Same as damage_whole(), but damages only a part of the output.
      *
      * @param box The output box to be damaged, in output-local coordinates.
+     * @param repaint Whether to automatically schedule an output repaint.
      */
-    void damage(const wlr_box& box);
+    void damage(const wlr_box& box, bool repaint = true);
 
     /**
      * Same as damage_whole(), but damages only a part of the output.
      *
-     * @param region The output region to be damaged, in output-local
-     *        coordinates.
+     * @param region The output region to be damaged, in output-local coordinates.
+     * @param repaint Whether to automatically schedule an output repaint.
      */
-    void damage(const wf::region_t& region);
+    void damage(const wf::region_t& region, bool repaint = true);
 
     /**
      * @return A box in output-local coordinates containing the given

--- a/src/api/wayfire/seat.hpp
+++ b/src/api/wayfire/seat.hpp
@@ -98,6 +98,11 @@ class seat_t
     wf::output_t *get_active_output();
 
     /**
+     * Notify clients and plugins of input activity on the seat
+     */
+    void notify_activity();
+
+    /**
      * Create and initialize a new seat.
      */
     seat_t(wl_display *display, std::string name);

--- a/src/api/wayfire/signal-definitions.hpp
+++ b/src/api/wayfire/signal-definitions.hpp
@@ -160,6 +160,22 @@ struct keyboard_focus_changed_signal
     wf::scene::node_ptr new_focus;
 };
 
+/**
+ * on: core
+ * when: Seat activity has happened after being idle.
+ */
+struct seat_activity_signal
+{};
+
+/**
+ * on: core
+ * when: idle inhibit changed.
+ */
+struct idle_inhibit_changed_signal
+{
+    bool inhibit;
+};
+
 /* ----------------------------------------------------------------------------/
  * Output signals
  * -------------------------------------------------------------------------- */

--- a/src/core/idle.cpp
+++ b/src/core/idle.cpp
@@ -1,25 +1,30 @@
 #include <wayfire/idle.hpp>
 #include <wayfire/util/log.hpp>
+#include "core/seat/input-manager.hpp"
 #include "core-impl.hpp"
 
 unsigned int wf::idle_inhibitor_t::inhibitors = 0;
 
-void wf::idle_inhibitor_t::notify_wlroots()
+void wf::idle_inhibitor_t::notify_update()
 {
     /* NOTE: inhibited -> NOT enabled */
-    wlr_idle_set_enabled(wf::get_core().protocols.idle, NULL, inhibitors == 0);
+    wlr_idle_notifier_v1_set_inhibited(wf::get_core().protocols.idle_notifier, inhibitors == 0);
+
+    wf::idle_inhibit_changed_signal data;
+    data.inhibit = (inhibitors != 0);
+    wf::get_core().emit(&data);
 }
 
 wf::idle_inhibitor_t::idle_inhibitor_t()
 {
     LOGD("creating idle inhibitor ", this, " previous count: ", inhibitors);
     inhibitors++;
-    notify_wlroots();
+    notify_update();
 }
 
 wf::idle_inhibitor_t::~idle_inhibitor_t()
 {
     LOGD("destroying idle inhibitor ", this, " previous count: ", inhibitors);
     inhibitors--;
-    notify_wlroots();
+    notify_update();
 }

--- a/src/core/opengl.cpp
+++ b/src/core/opengl.cpp
@@ -42,7 +42,7 @@ void gl_call(const char *func, uint32_t line, const char *glfunc)
     }
 
     LOGE("gles2: function ", glfunc, " in ", func, " line ", line, ": ",
-        gl_error_string(glGetError()));
+        gl_error_string(err));
 }
 
 namespace OpenGL

--- a/src/core/seat/cursor.cpp
+++ b/src/core/seat/cursor.cpp
@@ -45,14 +45,11 @@ void wf::cursor_t::add_new_device(wlr_input_device *dev)
 
 void wf::cursor_t::setup_listeners()
 {
-    auto& core = wf::get_core_impl();
-
     /* Dispatch pointer events to the pointer_t */
     on_frame.set_callback([&] (void*)
     {
         seat->priv->lpointer->handle_pointer_frame();
-        wlr_idle_notify_activity(core.protocols.idle,
-            core.get_current_seat());
+        wf::get_core().seat->notify_activity();
     });
     on_frame.connect(&cursor->events.frame);
 
@@ -64,7 +61,7 @@ void wf::cursor_t::setup_listeners()
         if (mode != wf::input_event_processing_mode_t::IGNORE) \
         { \
             seat->priv->lpointer->handle_pointer_ ## evname(ev, mode); \
-            wlr_idle_notify_activity(core.protocols.idle, core.get_current_seat()); \
+            wf::get_core().seat->notify_activity(); \
         } \
         emit_device_post_event_signal(ev); \
     }); \
@@ -98,7 +95,7 @@ void wf::cursor_t::setup_listeners()
                 static_cast<wf::tablet_t*>(ev->tablet->data); \
             tablet->handle_ ## evname(ev, handling_mode); \
         } \
-        wlr_idle_notify_activity(wf::get_core().protocols.idle, seat->seat); \
+        wf::get_core().seat->notify_activity(); \
         emit_device_event_signal(ev); \
     }); \
     on_tablet_ ## evname.connect(&cursor->events.tablet_tool_ ## evname);
@@ -130,22 +127,7 @@ void wf::cursor_t::init_xcursor()
     }
 
     xcursor = wlr_xcursor_manager_create(theme_ptr, size);
-
-    load_xcursor_scale(1);
-    for (auto& wo : wf::get_core().output_layout->get_current_configuration())
-    {
-        if (wo.second.source & wf::OUTPUT_IMAGE_SOURCE_SELF)
-        {
-            load_xcursor_scale(wo.first->scale);
-        }
-    }
-
     set_cursor("default");
-}
-
-void wf::cursor_t::load_xcursor_scale(float scale)
-{
-    wlr_xcursor_manager_load(xcursor, scale);
 }
 
 void wf::cursor_t::set_cursor(std::string name)
@@ -167,7 +149,7 @@ void wf::cursor_t::set_cursor(std::string name)
 
     idle_set_cursor.run_once([name, this] ()
     {
-        wlr_xcursor_manager_set_cursor_image(xcursor, name.c_str(), cursor);
+        wlr_cursor_set_xcursor(cursor, xcursor, name.c_str());
     });
 }
 

--- a/src/core/seat/cursor.hpp
+++ b/src/core/seat/cursor.hpp
@@ -49,7 +49,6 @@ struct cursor_t
 
     void init_xcursor();
     void setup_listeners();
-    void load_xcursor_scale(float scale);
 
     // Device event listeners
     wf::wl_listener_wrapper on_button, on_motion, on_motion_absolute, on_axis,

--- a/src/core/seat/drag-icon.cpp
+++ b/src/core/seat/drag-icon.cpp
@@ -127,7 +127,7 @@ wf::drag_icon_t::drag_icon_t(wlr_drag_icon *ic) : icon(ic)
 
     // Sometimes, the drag surface is reused between two or more drags.
     // In this case, when the drag starts, the icon is already mapped.
-    if (!icon->mapped)
+    if (!icon->surface->mapped)
     {
         root_node->set_enabled(false);
     }
@@ -147,8 +147,8 @@ wf::drag_icon_t::drag_icon_t(wlr_drag_icon *ic) : icon(ic)
         wf::get_core().seat->priv->drag_icon = nullptr;
     });
 
-    on_map.connect(&icon->events.map);
-    on_unmap.connect(&icon->events.unmap);
+    on_map.connect(&icon->surface->events.map);
+    on_unmap.connect(&icon->surface->events.unmap);
     on_destroy.connect(&icon->events.destroy);
 
 
@@ -175,8 +175,8 @@ wf::point_t wf::drag_icon_t::get_position()
 
     if (root_node->is_enabled())
     {
-        pos.x += icon->surface->sx;
-        pos.y += icon->surface->sy;
+        pos.x += icon->surface->current.dx;
+        pos.y += icon->surface->current.dy;
     }
 
     return {(int)pos.x, (int)pos.y};

--- a/src/core/seat/input-method-relay.cpp
+++ b/src/core/seat/input-method-relay.cpp
@@ -158,8 +158,17 @@ void wf::input_method_relay::disable_text_input(wlr_text_input_v3 *input)
         return;
     }
 
+    // on focus change, we disable on one text input and enable on another
+    // however, the former may also send us a disable request AFTER we've done the above
+    // let's just ignore repeated disable reuqests.
+    if (input == already_disabled_input)
+    {
+        return;
+    }
+
     wlr_input_method_v2_send_deactivate(input_method);
     send_im_state(input);
+    already_disabled_input = input;
 }
 
 void wf::input_method_relay::remove_text_input(wlr_text_input_v3 *input)

--- a/src/core/seat/input-method-relay.cpp
+++ b/src/core/seat/input-method-relay.cpp
@@ -49,6 +49,14 @@ wf::input_method_relay::input_method_relay()
         auto evt_input_method = static_cast<wlr_input_method_v2*>(data);
         assert(evt_input_method == input_method);
 
+        // FIXME: workaround focus change while preediting
+        if (focus_just_changed)
+        {
+            LOGI("focus_just_changed, ignore input method commit");
+            focus_just_changed = false;
+            return;
+        }
+
         auto *text_input = find_focused_text_input();
         if (text_input == nullptr)
         {

--- a/src/core/seat/input-method-relay.cpp
+++ b/src/core/seat/input-method-relay.cpp
@@ -439,8 +439,8 @@ wf::popup_surface::popup_surface(wf::input_method_relay *rel, wlr_input_popup_su
     on_unmap.set_callback([&] (void*) { unmap(); });
     on_commit.set_callback([&] (void*) { update_geometry(); });
 
-    on_map.connect(&surface->events.map);
-    on_unmap.connect(&surface->events.unmap);
+    on_map.connect(&surface->surface->events.map);
+    on_unmap.connect(&surface->surface->events.unmap);
     on_destroy.connect(&surface->events.destroy);
 }
 
@@ -519,20 +519,17 @@ void wf::popup_surface::update_geometry()
     }
 
     auto wlr_surface = text_input->input->focused_surface;
-    auto view = wf::wl_surface_to_wayfire_view(wlr_surface->resource);
-    auto toplevel    = toplevel_cast(view);
+    auto view     = wf::wl_surface_to_wayfire_view(wlr_surface->resource);
+    auto toplevel = toplevel_cast(view);
     auto g = toplevel->get_geometry();
     auto margins = toplevel->toplevel()->current().margins;
 
-    if (wlr_surface_is_xdg_surface(wlr_surface))
+    auto xdg_surface = wlr_xdg_surface_try_from_wlr_surface(wlr_surface);
+    if (xdg_surface)
     {
-        auto xdg_surface = wlr_xdg_surface_from_wlr_surface(wlr_surface);
-        if (xdg_surface)
-        {
-            // substract shadows etc; test app: d-feet
-            x -= xdg_surface->current.geometry.x;
-            y -= xdg_surface->current.geometry.y;
-        }
+        // substract shadows etc; test app: d-feet
+        x -= xdg_surface->current.geometry.x;
+        y -= xdg_surface->current.geometry.y;
     }
 
     damage();

--- a/src/core/seat/input-method-relay.hpp
+++ b/src/core/seat/input-method-relay.hpp
@@ -17,7 +17,9 @@ class input_method_relay
   private:
 
     wf::wl_listener_wrapper on_text_input_new,
-        on_input_method_new, on_input_method_commit, on_input_method_destroy;
+        on_input_method_new, on_input_method_commit, on_input_method_destroy,
+        on_grab_keyboard, on_grab_keyboard_destroy;
+    wlr_input_method_keyboard_grab_v2 *keyboard_grab = nullptr;
     text_input *find_focusable_text_input();
     text_input *find_focused_text_input();
     void set_focus(wlr_surface*);
@@ -34,6 +36,8 @@ class input_method_relay
         }
     };
 
+    bool should_grab(wlr_keyboard*);
+
   public:
 
     wlr_input_method_v2 *input_method = nullptr;
@@ -43,6 +47,8 @@ class input_method_relay
     void send_im_state(wlr_text_input_v3*);
     void disable_text_input(wlr_text_input_v3*);
     void remove_text_input(wlr_text_input_v3*);
+    bool handle_key(struct wlr_keyboard*, uint32_t, uint32_t, uint32_t);
+    bool handle_modifier(struct wlr_keyboard*);
     ~input_method_relay();
 };
 

--- a/src/core/seat/input-method-relay.hpp
+++ b/src/core/seat/input-method-relay.hpp
@@ -37,6 +37,7 @@ class input_method_relay
         {
             set_focus(nullptr);
         }
+
         focus_just_changed = true;
     };
 

--- a/src/core/seat/input-method-relay.hpp
+++ b/src/core/seat/input-method-relay.hpp
@@ -23,6 +23,7 @@ class input_method_relay
         on_grab_keyboard, on_grab_keyboard_destroy, on_new_popup_surface;
     wlr_input_method_keyboard_grab_v2 *keyboard_grab = nullptr;
     wlr_text_input_v3 *already_disabled_input = nullptr;
+    bool focus_just_changed = false;
     text_input *find_focusable_text_input();
     void set_focus(wlr_surface*);
 
@@ -36,6 +37,7 @@ class input_method_relay
         {
             set_focus(nullptr);
         }
+        focus_just_changed = true;
     };
 
     bool should_grab(wlr_keyboard*);

--- a/src/core/seat/input-method-relay.hpp
+++ b/src/core/seat/input-method-relay.hpp
@@ -22,6 +22,7 @@ class input_method_relay
         on_input_method_new, on_input_method_commit, on_input_method_destroy,
         on_grab_keyboard, on_grab_keyboard_destroy, on_new_popup_surface;
     wlr_input_method_keyboard_grab_v2 *keyboard_grab = nullptr;
+    wlr_text_input_v3 *already_disabled_input = nullptr;
     text_input *find_focusable_text_input();
     void set_focus(wlr_surface*);
 

--- a/src/core/seat/keyboard.cpp
+++ b/src/core/seat/keyboard.cpp
@@ -12,6 +12,7 @@
 #include "cursor.hpp"
 #include "touch.hpp"
 #include "input-manager.hpp"
+#include "input-method-relay.hpp"
 #include "wayfire/compositor-view.hpp"
 #include "wayfire/signal-definitions.hpp"
 
@@ -31,13 +32,14 @@ void wf::keyboard_t::setup_listeners()
 
         if (mode == input_event_processing_mode_t::IGNORE)
         {
-            wf::get_core().seat->notify_activity();
+            wlr_idle_notify_activity(wf::get_core().protocols.idle, seat->seat);
             emit_device_post_event_signal(ev);
             return;
         }
 
         seat->priv->set_keyboard(this);
-        if (!handle_keyboard_key(ev->keycode, ev->state) && (mode == input_event_processing_mode_t::FULL))
+        if (!handle_keyboard_key(ev->time_msec, ev->keycode,
+            ev->state) && (mode == input_event_processing_mode_t::FULL))
         {
             if (ev->state == WL_KEYBOARD_KEY_STATE_PRESSED)
             {
@@ -62,7 +64,7 @@ void wf::keyboard_t::setup_listeners()
             }
         }
 
-        wf::get_core().seat->notify_activity();
+        wlr_idle_notify_activity(wf::get_core().protocols.idle, seat->seat);
         emit_device_post_event_signal(ev);
     });
 
@@ -71,9 +73,13 @@ void wf::keyboard_t::setup_listeners()
         auto kbd  = static_cast<wlr_keyboard*>(data);
         auto seat = wf::get_core().get_current_seat();
 
-        wlr_seat_set_keyboard(seat, kbd);
-        wlr_seat_keyboard_send_modifiers(seat, &kbd->modifiers);
-        wf::get_core().seat->notify_activity();
+        if (!wf::get_core_impl().im_relay->handle_modifier(kbd))
+        {
+            wlr_seat_set_keyboard(seat, kbd);
+            wlr_seat_keyboard_send_modifiers(seat, &kbd->modifiers);
+        }
+
+        wlr_idle_notify_activity(wf::get_core().protocols.idle, seat);
     });
 
     on_key.connect(&handle->events.key);
@@ -281,7 +287,7 @@ bool wf::keyboard_t::has_only_modifiers()
     return true;
 }
 
-bool wf::keyboard_t::handle_keyboard_key(uint32_t key, uint32_t state)
+bool wf::keyboard_t::handle_keyboard_key(uint32_t time, uint32_t key, uint32_t state)
 {
     using namespace std::chrono;
 
@@ -294,7 +300,8 @@ bool wf::keyboard_t::handle_keyboard_key(uint32_t key, uint32_t state)
 
     if (state == WLR_KEY_PRESSED)
     {
-        if (check_vt_switch(wf::get_core().session, key, get_modifiers()))
+        auto session = wlr_backend_get_session(wf::get_core().backend);
+        if (check_vt_switch(session, key, get_modifiers()))
         {
             return true;
         }
@@ -333,6 +340,11 @@ bool wf::keyboard_t::handle_keyboard_key(uint32_t key, uint32_t state)
         }
 
         mod_binding_key = 0;
+    }
+
+    if (!handled_in_plugin)
+    {
+        handled_in_plugin |= wf::get_core_impl().im_relay->handle_key(handle, time, key, state);
     }
 
     return handled_in_plugin;

--- a/src/core/seat/keyboard.cpp
+++ b/src/core/seat/keyboard.cpp
@@ -32,7 +32,7 @@ void wf::keyboard_t::setup_listeners()
 
         if (mode == input_event_processing_mode_t::IGNORE)
         {
-            wlr_idle_notify_activity(wf::get_core().protocols.idle, seat->seat);
+            wlr_idle_notifier_v1_notify_activity(wf::get_core().protocols.idle_notifier, seat->seat);
             emit_device_post_event_signal(ev);
             return;
         }
@@ -64,7 +64,7 @@ void wf::keyboard_t::setup_listeners()
             }
         }
 
-        wlr_idle_notify_activity(wf::get_core().protocols.idle, seat->seat);
+        wlr_idle_notifier_v1_notify_activity(wf::get_core().protocols.idle_notifier, seat->seat);
         emit_device_post_event_signal(ev);
     });
 
@@ -79,7 +79,7 @@ void wf::keyboard_t::setup_listeners()
             wlr_seat_keyboard_send_modifiers(seat, &kbd->modifiers);
         }
 
-        wlr_idle_notify_activity(wf::get_core().protocols.idle, seat);
+        wlr_idle_notifier_v1_notify_activity(wf::get_core().protocols.idle_notifier, seat);
     });
 
     on_key.connect(&handle->events.key);
@@ -300,8 +300,7 @@ bool wf::keyboard_t::handle_keyboard_key(uint32_t time, uint32_t key, uint32_t s
 
     if (state == WLR_KEY_PRESSED)
     {
-        auto session = wlr_backend_get_session(wf::get_core().backend);
-        if (check_vt_switch(session, key, get_modifiers()))
+        if (check_vt_switch(wf::get_core().session, key, get_modifiers()))
         {
             return true;
         }

--- a/src/core/seat/keyboard.cpp
+++ b/src/core/seat/keyboard.cpp
@@ -31,7 +31,7 @@ void wf::keyboard_t::setup_listeners()
 
         if (mode == input_event_processing_mode_t::IGNORE)
         {
-            wlr_idle_notify_activity(wf::get_core().protocols.idle, seat->seat);
+            wf::get_core().seat->notify_activity();
             emit_device_post_event_signal(ev);
             return;
         }
@@ -62,7 +62,7 @@ void wf::keyboard_t::setup_listeners()
             }
         }
 
-        wlr_idle_notify_activity(wf::get_core().protocols.idle, seat->seat);
+        wf::get_core().seat->notify_activity();
         emit_device_post_event_signal(ev);
     });
 
@@ -73,7 +73,7 @@ void wf::keyboard_t::setup_listeners()
 
         wlr_seat_set_keyboard(seat, kbd);
         wlr_seat_keyboard_send_modifiers(seat, &kbd->modifiers);
-        wlr_idle_notify_activity(wf::get_core().protocols.idle, seat);
+        wf::get_core().seat->notify_activity();
     });
 
     on_key.connect(&handle->events.key);
@@ -294,8 +294,7 @@ bool wf::keyboard_t::handle_keyboard_key(uint32_t key, uint32_t state)
 
     if (state == WLR_KEY_PRESSED)
     {
-        auto session = wlr_backend_get_session(wf::get_core().backend);
-        if (check_vt_switch(session, key, get_modifiers()))
+        if (check_vt_switch(wf::get_core().session, key, get_modifiers()))
         {
             return true;
         }

--- a/src/core/seat/keyboard.hpp
+++ b/src/core/seat/keyboard.hpp
@@ -50,7 +50,7 @@ class keyboard_t
 
     std::chrono::steady_clock::time_point mod_binding_start;
 
-    bool handle_keyboard_key(uint32_t key, uint32_t state);
+    bool handle_keyboard_key(uint32_t time, uint32_t key, uint32_t state);
 
     /** Get the current locked mods */
     uint32_t get_locked_mods();

--- a/src/core/seat/seat.cpp
+++ b/src/core/seat/seat.cpp
@@ -58,8 +58,6 @@ void wf::seat_t::focus_output(wf::output_t *wo)
     if (wo)
     {
         LOGC(KBD, "focus output: ", wo->handle->name);
-        /* Move to the middle of the output if this is the first output */
-        wo->ensure_pointer((priv->active_output == nullptr));
 
         refocus();
 

--- a/src/core/seat/seat.cpp
+++ b/src/core/seat/seat.cpp
@@ -231,6 +231,13 @@ xkb_state*wf::seat_t::get_xkb_state()
     return nullptr;
 }
 
+void wf::seat_t::notify_activity()
+{
+    wlr_idle_notifier_v1_notify_activity(wf::get_core().protocols.idle_notifier, this->seat);
+    seat_activity_signal data;
+    wf::get_core().emit(&data);
+}
+
 std::vector<uint32_t> wf::seat_t::get_pressed_keys()
 {
     std::vector<uint32_t> pressed_keys{priv->pressed_keys.begin(), priv->pressed_keys.end()};

--- a/src/core/seat/touch.cpp
+++ b/src/core/seat/touch.cpp
@@ -35,7 +35,7 @@ wf::touch_interface_t::touch_interface_t(wlr_cursor *cursor, wlr_seat *seat,
             handle_touch_down(ev->touch_id, ev->time_msec, point, mode);
         }
 
-        wlr_idle_notify_activity(wf::get_core().protocols.idle, wf::get_core().get_current_seat());
+        wf::get_core().seat->notify_activity();
         emit_device_post_event_signal(ev);
     });
 
@@ -48,8 +48,7 @@ wf::touch_interface_t::touch_interface_t(wlr_cursor *cursor, wlr_seat *seat,
             handle_touch_up(ev->touch_id, ev->time_msec, mode);
         }
 
-        wlr_idle_notify_activity(wf::get_core().protocols.idle,
-            wf::get_core().get_current_seat());
+        wf::get_core().seat->notify_activity();
         emit_device_post_event_signal(ev);
     });
 
@@ -70,7 +69,7 @@ wf::touch_interface_t::touch_interface_t(wlr_cursor *cursor, wlr_seat *seat,
             handle_touch_motion(ev->touch_id, ev->time_msec, point, true, mode);
         }
 
-        wlr_idle_notify_activity(wf::get_core().protocols.idle, wf::get_core().get_current_seat());
+        wf::get_core().seat->notify_activity();
         emit_device_post_event_signal(ev);
     });
 
@@ -87,8 +86,7 @@ wf::touch_interface_t::touch_interface_t(wlr_cursor *cursor, wlr_seat *seat,
     on_frame.set_callback([&] (void*)
     {
         wlr_seat_touch_notify_frame(wf::get_core().get_current_seat());
-        wlr_idle_notify_activity(wf::get_core().protocols.idle,
-            wf::get_core().get_current_seat());
+        wf::get_core().seat->notify_activity();
     });
 
     on_up.connect(&cursor->events.touch_up);

--- a/src/core/view-access-interface.cpp
+++ b/src/core/view-access-interface.cpp
@@ -111,7 +111,7 @@ variant_t view_access_interface_t::get(const std::string & identifier, bool & er
             {
 #if WF_HAS_XWAYLAND
                 auto surf = _view->get_wlr_surface();
-                if (surf && wlr_surface_is_xwayland_surface(surf))
+                if (surf && wlr_xwayland_surface_try_from_wlr_surface(surf))
                 {
                     out = std::string("x-or");
                     break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -343,7 +343,7 @@ int main(int argc, char *argv[])
     /** TODO: move this to core_impl constructor */
     core.display = display;
     core.ev_loop = wl_display_get_event_loop(core.display);
-    core.backend = wlr_backend_autocreate(core.display);
+    core.backend = wlr_backend_autocreate(core.display, &core.session);
 
     int drm_fd = wlr_backend_get_drm_fd(core.backend);
     if (drm_fd < 0)
@@ -364,7 +364,8 @@ int main(int argc, char *argv[])
         }
     }
 
-    core.renderer  = wlr_gles2_renderer_create_with_drm_fd(drm_fd);
+    core.renderer = wlr_gles2_renderer_create_with_drm_fd(drm_fd);
+    assert(core.renderer);
     core.allocator = wlr_allocator_autocreate(core.backend, core.renderer);
     assert(core.allocator);
     core.egl = wlr_gles2_renderer_get_egl(core.renderer);

--- a/src/view/layer-shell/layer-shell-node.cpp
+++ b/src/view/layer-shell/layer-shell-node.cpp
@@ -46,10 +46,9 @@ wf::keyboard_focus_node_t wf::layer_shell_node_t::keyboard_refocus(wf::output_t 
     // have focus, or when they have an active grab.
     if (auto surf = view->get_wlr_surface())
     {
-        if (wlr_surface_is_layer_surface(surf))
+        if (wlr_layer_surface_v1 *layer_surface = wlr_layer_surface_v1_try_from_wlr_surface(surf))
         {
-            auto lsurf = wlr_layer_surface_v1_from_wlr_surface(surf);
-            if (lsurf->current.keyboard_interactive ==
+            if (layer_surface->current.keyboard_interactive ==
                 ZWLR_LAYER_SURFACE_V1_KEYBOARD_INTERACTIVITY_EXCLUSIVE)
             {
                 // Active grab

--- a/src/view/layer-shell/layer-shell.cpp
+++ b/src/view/layer-shell/layer-shell.cpp
@@ -54,6 +54,7 @@ class wayfire_layer_shell_view : public wf::view_interface_t
     std::string app_id;
     friend class wf::tracking_allocator_t<view_interface_t>;
     wayfire_layer_shell_view(wlr_layer_surface_v1 *lsurf);
+    bool keyboard_focus_enabled = true;
 
   public:
     wlr_layer_surface_v1 *lsurface;
@@ -110,7 +111,7 @@ class wayfire_layer_shell_view : public wf::view_interface_t
 
     wlr_surface *get_keyboard_focus_surface() override
     {
-        if (is_mapped() && priv->keyboard_focus_enabled)
+        if (is_mapped() && keyboard_focus_enabled)
         {
             return priv->wsurface;
         }
@@ -502,7 +503,7 @@ void wayfire_layer_shell_view::map()
     on_surface_commit.connect(&lsurface->surface->events.commit);
 
     /* Read initial data */
-    priv->keyboard_focus_enabled = lsurface->current.keyboard_interactive;
+    keyboard_focus_enabled = lsurface->current.keyboard_interactive;
 
     wf::scene::add_front(get_output()->node_for_layer(get_layer()), get_root_node());
     wf_layer_shell_manager::get_instance().handle_map(this);
@@ -544,7 +545,7 @@ void wayfire_layer_shell_view::commit()
     auto state = &lsurface->current;
     /* Update the keyboard focus enabled state. If a refocusing is needed, i.e
      * the view state changed, then this will happen when arranging layers */
-    priv->keyboard_focus_enabled = state->keyboard_interactive;
+    keyboard_focus_enabled = state->keyboard_interactive;
 
     if (state->committed)
     {

--- a/src/view/layer-shell/layer-shell.cpp
+++ b/src/view/layer-shell/layer-shell.cpp
@@ -414,8 +414,8 @@ wayfire_layer_shell_view::wayfire_layer_shell_view(wlr_layer_surface_v1 *lsurf) 
         wf_layer_shell_manager::get_instance().arrange_unmapped_view(this);
     });
 
-    on_map.connect(&lsurface->events.map);
-    on_unmap.connect(&lsurface->events.unmap);
+    on_map.connect(&lsurface->surface->events.map);
+    on_unmap.connect(&lsurface->surface->events.unmap);
     on_new_popup.connect(&lsurface->events.new_popup);
     on_commit_unmapped.connect(&lsurface->surface->events.commit);
 }
@@ -674,7 +674,7 @@ void wf::init_layer_shell()
 {
     static wf::wl_listener_wrapper on_created;
 
-    layer_shell_handle = wlr_layer_shell_v1_create(wf::get_core().display);
+    layer_shell_handle = wlr_layer_shell_v1_create(wf::get_core().display, 4);
     if (layer_shell_handle)
     {
         on_created.set_callback([] (void *data)

--- a/src/view/subsurface.cpp
+++ b/src/view/subsurface.cpp
@@ -21,7 +21,7 @@ wf::wlr_subsurface_controller_t::wlr_subsurface_controller_t(wlr_subsurface *sub
     sub->data = this;
 
     auto surface_node = std::make_shared<scene::wlr_surface_node_t>(sub->surface, true);
-    if (!sub->mapped)
+    if (!sub->surface->mapped)
     {
         surface_node->set_enabled(false);
     }
@@ -45,8 +45,8 @@ wf::wlr_subsurface_controller_t::wlr_subsurface_controller_t(wlr_subsurface *sub
         delete this;
     });
 
-    on_map.connect(&sub->events.map);
-    on_unmap.connect(&sub->events.unmap);
+    on_map.connect(&sub->surface->events.map);
+    on_unmap.connect(&sub->surface->events.unmap);
     on_destroy.connect(&sub->events.destroy);
 }
 

--- a/src/view/surface.cpp
+++ b/src/view/surface.cpp
@@ -16,9 +16,8 @@
 
 static void update_subsurface_position(wlr_surface *surface, int, int, void*)
 {
-    if (wlr_surface_is_subsurface(surface))
+    if (wlr_subsurface *sub = wlr_subsurface_try_from_wlr_surface(surface))
     {
-        auto sub = wlr_subsurface_from_wlr_surface(surface);
         if (sub->data)
         {
             ((wf::wlr_subsurface_controller_t*)sub->data)->get_subsurface_root()->update_offset();
@@ -64,7 +63,7 @@ wf::wlr_surface_controller_t::wlr_surface_controller_t(wlr_surface *surface,
         on_new_subsurface.emit(sub);
     }
 
-    if (!wlr_surface_is_subsurface(surface))
+    if (!wlr_subsurface_try_from_wlr_surface(surface))
     {
         on_commit.set_callback([=] (void*)
         {

--- a/src/view/view-impl.cpp
+++ b/src/view/view-impl.cpp
@@ -163,20 +163,20 @@ wayfire_view wf::wl_surface_to_wayfire_view(wl_resource *resource)
     }
 
     void *handle = NULL;
-    if (wlr_surface_is_xdg_surface(surface))
+    if (wlr_xdg_surface *xdg_surface = wlr_xdg_surface_try_from_wlr_surface(surface))
     {
-        handle = wlr_xdg_surface_from_wlr_surface(surface)->data;
+        handle = xdg_surface->data;
     }
 
-    if (wlr_surface_is_layer_surface(surface))
+    if (wlr_layer_surface_v1 *layer_shell_surface = wlr_layer_surface_v1_try_from_wlr_surface(surface))
     {
-        handle = wlr_layer_surface_v1_from_wlr_surface(surface)->data;
+        handle = layer_shell_surface->data;
     }
 
 #if WF_HAS_XWAYLAND
-    if (wlr_surface_is_xwayland_surface(surface))
+    if (wlr_xwayland_surface *xwayland_surface = wlr_xwayland_surface_try_from_wlr_surface(surface))
     {
-        handle = wlr_xwayland_surface_from_wlr_surface(surface)->data;
+        handle = xwayland_surface->data;
     }
 
 #endif

--- a/src/view/view-impl.hpp
+++ b/src/view/view-impl.hpp
@@ -30,11 +30,9 @@ namespace wf
 class view_interface_t::view_priv_impl
 {
   public:
-    wlr_surface *wsurface = nullptr;
-    size_t last_view_cnt  = 0;
-
-    bool keyboard_focus_enabled = true;
-    uint32_t allowed_actions    = VIEW_ALLOW_ALL;
+    wlr_surface *wsurface    = nullptr;
+    size_t last_view_cnt     = 0;
+    uint32_t allowed_actions = VIEW_ALLOW_ALL;
 
     uint32_t edges = 0;
     wlr_box minimize_hint = {0, 0, 0, 0};

--- a/src/view/view.cpp
+++ b/src/view/view.cpp
@@ -84,7 +84,7 @@ wlr_box wf::view_interface_t::get_bounding_box()
 
 bool wf::view_interface_t::is_focusable() const
 {
-    return priv->keyboard_focus_enabled;
+    return true;
 }
 
 void wf::view_interface_t::damage()

--- a/src/view/wlr-surface-node.cpp
+++ b/src/view/wlr-surface-node.cpp
@@ -328,7 +328,7 @@ class wf::scene::wlr_surface_node_t::wlr_surface_render_instance_t : public rend
     {
         if (self->surface)
         {
-            wlr_presentation_surface_sampled_on_output(wf::get_core_impl().protocols.presentation,
+            wlr_presentation_surface_scanned_out_on_output(wf::get_core_impl().protocols.presentation,
                 self->surface, output->handle);
         }
     }
@@ -361,7 +361,7 @@ class wf::scene::wlr_surface_node_t::wlr_surface_render_instance_t : public rend
             return direct_scanout::OCCLUSION;
         }
 
-        wlr_presentation_surface_sampled_on_output(
+        wlr_presentation_surface_scanned_out_on_output(
             wf::get_core().protocols.presentation, wlr_surf, output->handle);
         wlr_output_attach_buffer(output->handle, &wlr_surf->buffer->base);
 

--- a/src/view/xdg-shell.cpp
+++ b/src/view/xdg-shell.cpp
@@ -41,7 +41,6 @@ wayfire_xdg_popup::wayfire_xdg_popup(wlr_xdg_popup *popup) : wf::view_interface_
     this->popup_parent = wf::wl_surface_to_wayfire_view(popup->parent->resource).get();
     this->popup = popup;
     this->role  = wf::VIEW_ROLE_UNMANAGED;
-    this->priv->keyboard_focus_enabled = false;
 
     if (!dynamic_cast<wayfire_xdg_popup*>(popup_parent.get()))
     {
@@ -373,4 +372,9 @@ void wf::init_xdg_shell()
         });
         on_xdg_created.connect(&xdg_handle->events.new_surface);
     }
+}
+
+bool wayfire_xdg_popup::is_focusable() const
+{
+    return false;
 }

--- a/src/view/xdg-shell.cpp
+++ b/src/view/xdg-shell.cpp
@@ -76,8 +76,8 @@ wayfire_xdg_popup::wayfire_xdg_popup(wlr_xdg_popup *popup) : wf::view_interface_
         unconstrain();
     });
 
-    on_map.connect(&popup->base->events.map);
-    on_unmap.connect(&popup->base->events.unmap);
+    on_map.connect(&popup->base->surface->events.map);
+    on_unmap.connect(&popup->base->surface->events.unmap);
     on_destroy.connect(&popup->base->events.destroy);
     on_new_popup.connect(&popup->base->events.new_popup);
     on_ping_timeout.connect(&popup->base->events.ping_timeout);
@@ -166,10 +166,10 @@ void wayfire_xdg_popup::update_position()
 
     // Offset relative to the parent surface
     wf::pointf_t popup_offset = {1.0 * popup->current.geometry.x, 1.0 * popup->current.geometry.y};
-    if (wlr_surface_is_xdg_surface(popup->parent))
+    if (wlr_xdg_surface *xdg_surface = wlr_xdg_surface_try_from_wlr_surface(popup->parent))
     {
         wlr_box box;
-        wlr_xdg_surface_get_geometry(wlr_xdg_surface_from_wlr_surface(popup->parent), &box);
+        wlr_xdg_surface_get_geometry(xdg_surface, &box);
         popup_offset.x += box.x;
         popup_offset.y += box.y;
     }

--- a/src/view/xdg-shell.hpp
+++ b/src/view/xdg-shell.hpp
@@ -47,6 +47,8 @@ class wayfire_xdg_popup : public wf::view_interface_t
     std::string get_app_id() override final;
     std::string get_title() override final;
 
+    bool is_focusable() const override final;
+
     void move(int x, int y);
     wf::geometry_t get_geometry();
     virtual wlr_surface *get_keyboard_focus_surface() override;

--- a/src/view/xwayland/xwayland-toplevel-view.hpp
+++ b/src/view/xwayland/xwayland-toplevel-view.hpp
@@ -174,7 +174,6 @@ class wayfire_xwayland_view : public wf::toplevel_view_interface_t, public wayfi
     wayfire_xwayland_view(wlr_xwayland_surface *xww) :
         wayfire_xwayland_view_internal_base(xww)
     {
-        LOGE("new xwayland surface ", xw->title, " class: ", xw->class_t, " instance: ", xw->instance);
         this->toplevel = std::make_shared<wf::xw::xwayland_toplevel_t>(xw);
         toplevel->connect(&on_toplevel_applied);
         this->priv->toplevel = toplevel;

--- a/src/view/xwayland/xwayland-unmanaged-view.hpp
+++ b/src/view/xwayland/xwayland-unmanaged-view.hpp
@@ -164,12 +164,12 @@ class wayfire_unmanaged_xwayland_view : public wayfire_xwayland_view_internal_ba
          * plugins can detect that this view can have keyboard focus.
          *
          * Note: only actual override-redirect views should get their focus disabled */
-        priv->keyboard_focus_enabled = (!xw->override_redirect ||
+        kb_focus_enabled = (!xw->override_redirect ||
             wlr_xwayland_or_surface_wants_focus(xw));
 
         wf::scene::readd_front(get_output()->node_for_layer(wf::scene::layer::UNMANAGED), get_root_node());
 
-        if (priv->keyboard_focus_enabled)
+        if (kb_focus_enabled)
         {
             wf::get_core().default_wm->focus_request(self());
         }


### PR DESCRIPTION
## wlr_input_popup_surface_v2 map与unmap方法移除

在commit id为`743da5c0ae723098fe772aadb93810f60e700ab9`的提交中，提交信息为

> input-method: use unified map logic

关联issue: [[compositor: unify map logic](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4043)](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/4043)

相关的sway提交: [[chore: chase wlroots map logic unification](https://github.com/swaywm/sway/pull/7498)](https://github.com/swaywm/sway/pull/7498)

## wlr_surface_is_xdg_surface以及wlr_xdg_surface_from_wlr_surface被移除

在Commit id为`711a1a3ed42150fdbc716e80719d482006075f69`的提交中，提交信息为

> xdg-shell: convert to try_from
>
> References: https://gitlab.freedesktop.org/wlroots/wlroots/-/issues/884

关联issue: [[Convert fromwlrsurface() functions to tryfrom pattern](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/3991)](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/3991)

相关sway提交: [[Convert to tryfromwlrsurface()](https://github.com/swaywm/sway/pull/7422)](https://github.com/swaywm/sway/pull/7422)

## wlr_idle_notify_activity被移除

在commit id为`a289f812d62059d5aac92cbd374dcb7b03bb08a6`的提交中，提交信息为

> drop KDE idle protocol support

关联Issue: [Drop support for KDE&apos;s idle protocol](https://gitlab.freedesktop.org/wlroots/wlroots/-/issues/3510)

引申issue: [[idle-notify-v1: new protocol implementation](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/3753)](https://gitlab.freedesktop.org/wlroots/wlroots/-/merge_requests/3753)

* 因为idle-notify-v1被加入到wlroots中，弃用了过去的KDE idle协议

涉及函数`wlr_idle_notify_activity`改为`wlr_idle_notifier_v1_notify_activity`

详情改动commit连接: https://github.com/lilydjwg/wayfire/commit/cc0080b68d608a5f74300ea1296638dd796a941d